### PR TITLE
change aExtPanId to aExtendedPanId

### DIFF
--- a/include/openthread/commissioner.h
+++ b/include/openthread/commissioner.h
@@ -282,7 +282,7 @@ OTAPI otCommissionerState OTCALL otCommissionerGetState(otInstance *aInstance);
  *
  */
 OTAPI otError OTCALL otCommissionerGeneratePSKc(otInstance *aInstance, const char *aPassPhrase,
-                                                const char *aNetworkName, const uint8_t *aExtPanId,
+                                                const char *aNetworkName, const uint8_t *aExtendedPanId,
                                                 uint8_t *aPSKc);
 
 /**


### PR DESCRIPTION
This is the last occurrence in the API that uses extPanId (where extendedPanId is used elsewhere in the API)