### PR TITLE
[qpg] Add ability to pick custom lib for MTD/FTD

### DIFF
--- a/examples/apps/cli/ftd.cmake
+++ b/examples/apps/cli/ftd.cmake
@@ -33,11 +33,15 @@ add_executable(ot-cli-ftd
 
 target_include_directories(ot-cli-ftd PRIVATE ${COMMON_INCLUDES})
 
+if(NOT DEFINED OT_PLATFORM_LIB_FTD)
+    set(OT_PLATFORM_LIB_FTD ${OT_PLATFORM_LIB})
+endif()
+
 target_link_libraries(ot-cli-ftd PRIVATE
     openthread-cli-ftd
-    ${OT_PLATFORM_LIB}
+    ${OT_PLATFORM_LIB_FTD}
     openthread-ftd
-    ${OT_PLATFORM_LIB}
+    ${OT_PLATFORM_LIB_FTD}
     openthread-cli-ftd
     ${OT_MBEDTLS}
     ot-config

--- a/examples/apps/cli/mtd.cmake
+++ b/examples/apps/cli/mtd.cmake
@@ -33,11 +33,15 @@ add_executable(ot-cli-mtd
 
 target_include_directories(ot-cli-mtd PRIVATE ${COMMON_INCLUDES})
 
+if(NOT DEFINED OT_PLATFORM_LIB_MTD)
+    set(OT_PLATFORM_LIB_MTD ${OT_PLATFORM_LIB})
+endif()
+
 target_link_libraries(ot-cli-mtd PRIVATE
     openthread-cli-mtd
-    ${OT_PLATFORM_LIB}
+    ${OT_PLATFORM_LIB_MTD}
     openthread-mtd
-    ${OT_PLATFORM_LIB}
+    ${OT_PLATFORM_LIB_MTD}
     openthread-cli-mtd
     ${OT_MBEDTLS}
     ot-config

--- a/examples/apps/cli/radio.cmake
+++ b/examples/apps/cli/radio.cmake
@@ -33,11 +33,15 @@ add_executable(ot-cli-radio
 
 target_include_directories(ot-cli-radio PRIVATE ${COMMON_INCLUDES})
 
+if(NOT DEFINED OT_PLATFORM_LIB_RCP)
+    set(OT_PLATFORM_LIB_RCP ${OT_PLATFORM_LIB})
+endif()
+
 target_link_libraries(ot-cli-radio PRIVATE
     openthread-cli-radio
-    ${OT_PLATFORM_LIB}
+    ${OT_PLATFORM_LIB_RCP}
     openthread-radio-cli
-    ${OT_PLATFORM_LIB}
+    ${OT_PLATFORM_LIB_RCP}
     openthread-cli-radio
     ${OT_MBEDTLS}
     ot-config

--- a/examples/apps/ncp/ftd.cmake
+++ b/examples/apps/ncp/ftd.cmake
@@ -33,11 +33,15 @@ add_executable(ot-ncp-ftd
 
 target_include_directories(ot-ncp-ftd PRIVATE ${COMMON_INCLUDES})
 
+if(NOT DEFINED OT_PLATFORM_LIB_FTD)
+    set(OT_PLATFORM_LIB_FTD ${OT_PLATFORM_LIB})
+endif()
+
 target_link_libraries(ot-ncp-ftd PRIVATE
     openthread-ncp-ftd
-    ${OT_PLATFORM_LIB}
+    ${OT_PLATFORM_LIB_FTD}
     openthread-ftd
-    ${OT_PLATFORM_LIB}
+    ${OT_PLATFORM_LIB_FTD}
     openthread-ncp-ftd
     ${OT_MBEDTLS}
     ot-config

--- a/examples/apps/ncp/mtd.cmake
+++ b/examples/apps/ncp/mtd.cmake
@@ -33,11 +33,15 @@ add_executable(ot-ncp-mtd
 
 target_include_directories(ot-ncp-mtd PRIVATE ${COMMON_INCLUDES})
 
+if(NOT DEFINED OT_PLATFORM_LIB_MTD)
+    set(OT_PLATFORM_LIB_MTD ${OT_PLATFORM_LIB})
+endif()
+
 target_link_libraries(ot-ncp-mtd PRIVATE
     openthread-ncp-mtd
-    ${OT_PLATFORM_LIB}
+    ${OT_PLATFORM_LIB_MTD}
     openthread-mtd
-    ${OT_PLATFORM_LIB}
+    ${OT_PLATFORM_LIB_MTD}
     openthread-ncp-mtd
     ${OT_MBEDTLS}
     ot-config

--- a/examples/apps/ncp/rcp.cmake
+++ b/examples/apps/ncp/rcp.cmake
@@ -33,11 +33,15 @@ add_executable(ot-rcp
 
 target_include_directories(ot-rcp PRIVATE ${COMMON_INCLUDES})
 
+if(NOT DEFINED OT_PLATFORM_LIB_RCP)
+    set(OT_PLATFORM_LIB_RCP ${OT_PLATFORM_LIB})
+endif()
+
 target_link_libraries(ot-rcp PRIVATE
     openthread-rcp
-    ${OT_PLATFORM_LIB}
+    ${OT_PLATFORM_LIB_RCP}
     openthread-radio
-    ${OT_PLATFORM_LIB}
+    ${OT_PLATFORM_LIB_RCP}
     openthread-rcp
     ot-config
 )

--- a/src/ncp/ftd.cmake
+++ b/src/ncp/ftd.cmake
@@ -46,7 +46,6 @@ target_link_libraries(openthread-ncp-ftd
     PUBLIC
         openthread-ftd
     PRIVATE
-        ${OT_PLATFORM_LIB}
         ${OT_MBEDTLS}
         openthread-hdlc
         openthread-spinel-ncp


### PR DESCRIPTION
This PR enables different libraries option for ftd, mtd and rcp builds.
Proposed change will make it possible to supply trimmed version of platform library for memory-constrained devices.